### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Welcome to django-highlightjs
   :target: https://coveralls.io/r/MounirMesselmeni/django-highlightjs?branch=master
 
 
-.. image:: https://pypip.in/version/django-highlightjs/badge.svg
+.. image:: https://img.shields.io/pypi/v/django-highlightjs.svg
     :target: https://pypi.python.org/pypi/django-highlightjs/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-highlightjs))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-highlightjs`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.